### PR TITLE
WorkerConfiguration.worker_schedule property

### DIFF
--- a/settei/presets/celery.py
+++ b/settei/presets/celery.py
@@ -3,14 +3,36 @@
 
 """
 import collections.abc
+import datetime
+import re
 import typing
+import warnings
 
+from celery.schedules import crontab
+from celery.utils.imports import symbol_by_name
 from kombu.utils import cached_property
 
-from ..base import config_property
+from ..base import ConfigWarning, config_property
 from .logging import LoggingConfiguration
 
-__all__ = 'WorkerConfiguration',
+__all__ = 'SCHEDULE_EXPR_PATTERN', 'WorkerConfiguration',
+
+
+SCHEDULE_EXPR_PATTERN = re.compile(r'''
+    ^
+    (?:
+        (?P<module_path>
+            (?:    [^\d\W] \w* )
+            (?: \. [^\d\W] \w* )*
+        )
+        :
+    )?
+    (?P<call>
+        (?P<function> [^\d\W] \w* )
+        \( .*? \)
+    )
+    $
+''', re.VERBOSE | re.UNICODE)
 
 
 class WorkerConfiguration(LoggingConfiguration):
@@ -38,20 +60,124 @@ class WorkerConfiguration(LoggingConfiguration):
     )
 
     @cached_property
+    def worker_schedule(self) -> typing.Mapping[str,
+                                                typing.Mapping[str, object]]:
+        """(:class:`typing.Mapping`\ [:class:`str`,
+        :class:`typing.Mapping`\ [:class:`str`, :class:`object`]])
+        The schedule table for Celery Beat, scheduler for periodic tasks.
+
+        There's some preprocessing before reading configuration.
+        Since TOML doesn't have custom types, you can't represent
+        :class:`~datetime.timedelta` or :class:`~celery.schedules.crontab`
+        values from the configuration file.  To workaround the problem,
+        it evaluates strings like ``'f()'`` pattern if they are appeared
+        in a ``schedule`` field.
+
+        For example, if the following configuration is present:
+
+        .. code-block:: toml
+
+           [worker.celerybeat_schedule.add-every-30-seconds]
+           task = "tasks.add"
+           schedule = "timedelta(seconds=30)"  # string to be evaluated
+           args = [16, 16]
+
+        it becomes translated to:
+
+        .. code-block:: python
+
+           CELERYBEAT_SCHEDULE = {
+               'add-every-30-seconds': {
+                   'task': 'tasks.add',
+                   'schedule': datetime.timedelta(seconds=30),  # evaluated!
+                   'args': (16, 16),
+               },
+           }
+
+        Note that although :class:`~datetime.timedelta` and
+        :class:`~celery.schedules.crontab` is already present in the context,
+        you need to import things if other types.  It can also parse and
+        evaluate the patterns like ``'module.path:func()'``.
+
+        Also ``args`` fields are translated from array to tuple.
+
+        See also Celery's docs about periodic tasks:
+
+        http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html
+
+        .. versionadded:: 0.2.1
+
+        """
+        raw_config = self.config.get('worker', {})
+        try:
+            table = raw_config['celerybeat_schedule']
+        except KeyError:
+            try:
+                table = next(
+                    v for k, v in raw_config.items()
+                    if k.lower() == 'celerybeat_schedule'
+                )
+            except StopIteration:
+                return {}
+        base_ctx = {'timedelta': datetime.timedelta, 'crontab': crontab}
+        new_table = {}
+        for name, value in table.items():
+            try:
+                schedule = value['schedule']
+            except KeyError:
+                warnings.warn(
+                    'the {0!r} of worker.celerybeat_schedule lacks schedule '
+                    'field'.format(name),
+                    ConfigWarning
+                )
+                new_table[name] = value
+                continue
+            if not isinstance(schedule, str):
+                warnings.warn(
+                    'the schedule field of worker.celerybeat_schedule.{0} '
+                    'has to be a string'.format(name),
+                    ConfigWarning
+                )
+                new_table[name] = value
+                continue
+            match = SCHEDULE_EXPR_PATTERN.match(schedule)
+            if not match:
+                warnings.warn(
+                    'the schedule field of worker.celerybeat_schedule.{0} '
+                    'is invalid format.  it has to be like "f(args)" or '
+                    '"module.path:func(args)'.format(name),
+                    ConfigWarning
+                )
+                new_table[name] = value
+                continue
+            ctx = base_ctx.copy()
+            if match.group('module_path'):
+                import_path = '{}:{}'.format(match.group('module_path'),
+                                             match.group('function'))
+                ctx[match.group('function')] = symbol_by_name(import_path)
+            new_table[name] = dict(value,
+                                   args=tuple(value.get('args', ())),
+                                   schedule=eval(match.group('call'), ctx))
+        return new_table
+
+    @cached_property
     def worker_config(self) -> typing.Mapping[str, object]:
         """(:class:`typing.Mapping`\ [:class:`str`, :class:`object`])
         The configuration maping for worker that will go to :attr:`Celery.conf
         <celery.Celery.conf>`.
 
         """
-        celery_config = self.config.get('worker', {})
-        if not isinstance(celery_config, collections.abc.Mapping):
+        raw_config = self.config.get('worker', {})
+        if isinstance(raw_config, collections.abc.Mapping):
+            celery_config = {k.upper(): v for k, v in raw_config.items()}
+        else:
             celery_config = {}
         celery_config.update(
             BROKER_URL=self.worker_broker_url,
-            CELERY_RESULT_BACKEND=self.worker_result_backend
+            CELERY_RESULT_BACKEND=self.worker_result_backend,
+            CELERYBEAT_SCHEDULE=self.worker_schedule
         )
-        return {k.upper(): v for k, v in celery_config.items()}
+        return celery_config
 
     def on_worker_loaded(self, app):
         """Be invoked when a Celery app is ready.

--- a/tests/presets/celery_test.py
+++ b/tests/presets/celery_test.py
@@ -1,3 +1,7 @@
+import datetime
+
+from celery.schedules import crontab
+
 from .logging_test import test_configure_logging as configure_test
 from settei.presets.celery import WorkerConfiguration
 
@@ -30,3 +34,65 @@ def test_workeron_loaded():
 
 def test_configure_logging():
     configure_test('settei.workertest.', WorkerConfiguration)
+
+
+def test_worker_schedule():
+    # timedelta
+    conf = WorkerConfiguration({
+        'worker': {
+            'broker_url': 'redis://',
+            'celery_result_backend': 'redis://',
+            'celerybeat_schedule': {
+                'add-every-30-seconds': {
+                    'task': 'tasks.add',
+                    'schedule': 'timedelta(seconds=30)',
+                },
+            },
+        }
+    })
+    assert conf.worker_schedule == {
+        'add-every-30-seconds': {
+            'task': 'tasks.add',
+            'schedule': datetime.timedelta(seconds=30),
+            'args': (),
+        },
+    }
+    assert conf.worker_config['CELERYBEAT_SCHEDULE'] == conf.worker_schedule
+    # crontab
+    conf2 = WorkerConfiguration({
+        'worker': {
+            'broker_url': 'redis://',
+            'celery_result_backend': 'redis://',
+            'celerybeat_schedule': {
+                'add-every-minute': {
+                    'task': 'tasks.add',
+                    'schedule': "crontab(minute='*')",
+                    'args': [16, 16],
+                },
+            },
+        }
+    })
+    assert conf2.worker_schedule == {
+        'add-every-minute': {
+            'task': 'tasks.add',
+            'schedule': crontab(minute='*'),
+            'args': (16, 16),
+        },
+    }
+    assert conf2.worker_config['CELERYBEAT_SCHEDULE'] == conf2.worker_schedule
+    # import path
+    conf3 = WorkerConfiguration({
+        'worker': {
+            'broker_url': 'redis://',
+            'celery_result_backend': 'redis://',
+            'celerybeat_schedule': {
+                'add-every-minute': {
+                    'task': 'tasks.add',
+                    'schedule': "celery.schedules:crontab(minute='*')",
+                    'args': [16, 16],
+                },
+            },
+        }
+    })
+    assert conf3.worker_schedule == conf2.worker_schedule
+    assert conf3.worker_config['CELERYBEAT_SCHEDULE'] == conf3.worker_schedule

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
     python setup.py build_sphinx
 
 [flake8]
-exclude=docs
+exclude=.tox,docs
 
 [pytest]
 python_classes=


### PR DESCRIPTION
Since TOML can't present values of custom types like `datetime.timedelta`/`celery.schedules.crontab`, we need proprocessing to translate mini language in strings to the proper values.

It parses a (near-)subset of Python expression w/ import string in the `schedule` field and evaluates it into a Python object.

See also the docstring of `WorkerConfiguration.worker_schedule` property.
