### PR TITLE
Replace tsukkomi with typeguard

### DIFF
--- a/settei/presets/flask.py
+++ b/settei/presets/flask.py
@@ -5,7 +5,7 @@
 import collections.abc
 import typing
 
-from tsukkomi.typed import typechecked
+from typeguard import typechecked
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.utils import cached_property
 

--- a/settei/version.py
+++ b/settei/version.py
@@ -3,9 +3,9 @@
 
 """
 
-#: (:class:`typing.Tuple`[:class:`int`, :class:`int`, :class:`int`])
+#: (:class:`typing.Tuple`\ [:class:`int`, :class:`int`, :class:`int`])
 #: The triple of version numbers e.g. ``(1, 2, 3)``.
-VERSION_INFO = (0, 2, 2)
+VERSION_INFO = (0, 3, 0)
 
 #: (:class:`str`) The version string e.g. ``'1.2.3'``.
 VERSION = '{}.{}.{}'.format(*VERSION_INFO)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import ast
+import io
 import os
 import os.path
 
@@ -47,8 +48,9 @@ def get_version():
 
 
 def readme():
+    name = os.path.join(os.path.dirname(__file__), 'README.rst')
     try:
-        with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
+        with io.open(name, encoding='utf-8') as f:
             return f.read()
     except (IOError, OSError):
         return

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 install_requires = [
     'pytoml >= 0.1.10, < 0.2.0',
     'setuptools',
-    'tsukkomi >= 0.0.5',
+    'typeguard >= 2.1.1',
 ]
 extras_require = {
     'flask': ['Flask', 'Werkzeug'],

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -4,7 +4,15 @@ import warnings
 
 from pytest import mark, raises
 
-from settei.base import Configuration, ConfigWarning, config_property
+from settei.base import (Configuration, ConfigWarning,
+                         config_property, get_union_types)
+
+
+def test_get_union_types():
+    assert get_union_types(typing.Union[int, str]) == (int, str)
+    assert get_union_types(typing.Union[bool, list, set]) == (bool, list, set)
+    assert get_union_types(str) is None
+    assert get_union_types('asdf') is None
 
 
 def test_package_level_api_compatibility():


### PR DESCRIPTION
Because [typeguard][1] seems more reliable and well maintained in these days than tsukkomi, and I find it promising, I suggest to replace tsukkomi with typeguard.

[1]: https://github.com/agronholm/typeguard