### PR TITLE
ConfigError, ConfigKeyError, and ConfigTypeError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ python:
 - 3.5
 install:
 - pip install tox-travis
-script: tox
+script:
+- tox
+# Ensure changelog was written:
+- git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep docs/changes.rst

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,11 @@ Verison 0.4.0
 
 To be released.
 
+- :exc:`~settei.base.ConfigError`, and :exc:`~settei.base.ConfigKeyError`.
+  Prior to 0.4.0, :class:`~settei.base.Configuration` had raised Python's
+  built-in :exc:`KeyError` on missing keys, but since 0.4.0 it became to raise
+  :exc:`~settei.base.ConfigKeyError`, a subtype of :exc:`KeyError`, instead.
+
 
 Version 0.3.0
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,10 +6,18 @@ Verison 0.4.0
 
 To be released.
 
-- :exc:`~settei.base.ConfigError`, and :exc:`~settei.base.ConfigKeyError`.
+- :exc:`~settei.base.ConfigError`, :exc:`~settei.base.ConfigKeyError`, and
+  :exc:`~settei.base.ConfigTypeError`.
+
   Prior to 0.4.0, :class:`~settei.base.Configuration` had raised Python's
   built-in :exc:`KeyError` on missing keys, but since 0.4.0 it became to raise
   :exc:`~settei.base.ConfigKeyError`, a subtype of :exc:`KeyError`, instead.
+
+  In the same manner, while prior to 0.4.0, it had raised Python's
+  built-in :exc:`TypeError` when a configured value is not of a type it expects,
+  but since 0.4.0 it became to raise :exc:`~settei.base.ConfigTypeError`
+  instead.  :exc:`~settei.base.ConfigTypeError` is also a subtype of
+  :class:`TypeError`.
 
 
 Version 0.3.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,0 +1,75 @@
+Changlog
+========
+
+Verison 0.4.0
+-------------
+
+To be released.
+
+
+Version 0.3.0
+-------------
+
+Released on January 22, 2017.
+
+- As tsukkomi_ is now abandoned, it's replaced by typeguard_.
+
+.. _typeguard: https://github.com/agronholm/typeguard
+
+
+Version 0.2.2
+-------------
+
+Released on November 18, 2016.  Note that the version 0.2.1 has never been
+released due to our mistake on versioning.
+
+- :class:`~settei.presets.celery.WorkerConfiguration` became to have
+  :attr:`~settei.presets.celery.WorkerConfiguration.worker_schedule`
+  config property to configure Celery beat --- Celery's periodic tasks.
+
+
+Version 0.2.0
+-------------
+
+Released on July 13, 2016.
+
+- :mod:`settei` became a package (had been a module), which contains
+  :mod:`settei.base` module.
+- :class:`settei.Configuration`, :class:`settei.ConfigWarning`, and
+  :class:`settei.config_property` were moved to :mod:`settei.base` module.
+  Although aliases for these previous import paths will be there for a while,
+  we recommend to import them from :mod:`settei.base` mdoule since they are
+  deprecated.
+
+- Presets were introduced: :mod:`settei.presets`.
+
+  - :mod:`settei.presets.celery` is for configuring Celery_ apps.
+  - :mod:`settei.presets.flask` is for configuring Flask_ web apps.
+  - :mod:`settei.presets.logging` is for configuring Python standard
+    :mod:`logging` system.
+
+- :mod:`settei.version` module was added.
+- typeannotations_ was replaced by tsukkomi_.
+- Settei now requires pytoml_ 0.1.10 or higher.  (It had required 0.1.7 or
+  higher.)
+
+.. _Celery: http://www.celeryproject.org/
+.. _flask: http://flask.pocoo.org/
+.. _typeannotations: https://github.com/ceronman/typeannotations
+.. _tsukkomi: https://github.com/spoqa/tsukkomi
+.. _pytoml: https://github.com/avakar/pytoml
+
+
+Version 0.1.1
+-------------
+
+Released on April 15, 2016.
+
+- :class:`settei.base.config_property` became to support :data:`typing.Union`
+  type.
+
+
+Version 0.1.0
+-------------
+
+Released on April 1, 2016.  Initial release.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,14 +5,11 @@
 
 .. include:: ../README.rst
 
-
-References
-----------
-
 .. toctree::
    :maxdepth: 3
 
    settei
+   changes
 
 
 Indices and tables

--- a/settei/__init__.py
+++ b/settei/__init__.py
@@ -1,7 +1,7 @@
 """:mod:`settei` --- App object holding configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2016 Spoqa, Inc.
+:copyright: (c) 2016---2017 Spoqa, Inc.
 :license: Apache License 2.0, see LICENSE for more details.
 
 """

--- a/settei/base.py
+++ b/settei/base.py
@@ -1,6 +1,8 @@
 """:mod:`settei.base` --- Basic app object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 0.2.0
+
 """
 import collections.abc
 import pathlib

--- a/settei/presets/__init__.py
+++ b/settei/presets/__init__.py
@@ -1,4 +1,6 @@
 """:mod:`settei.presets` --- Richer presets for several frameworks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 0.2.0
+
 """

--- a/settei/presets/celery.py
+++ b/settei/presets/celery.py
@@ -105,7 +105,7 @@ class WorkerConfiguration(LoggingConfiguration):
 
         http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html
 
-        .. versionadded:: 0.2.1
+        .. versionadded:: 0.2.2
 
         """
         raw_config = self.config.get('worker', {})

--- a/settei/presets/flask.py
+++ b/settei/presets/flask.py
@@ -1,6 +1,8 @@
 """:mod:`settei.presets.flask` --- Preset for Flask apps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 0.2.0
+
 """
 import collections.abc
 import typing

--- a/settei/presets/logging.py
+++ b/settei/presets/logging.py
@@ -1,6 +1,8 @@
 """:mod:`settei.presets.logging` --- Preset for :mod:`logging` configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 0.2.0
+
 Preset for apps holding :mod:`logging` configuration.  Logging can be
 configured through TOML file e.g.:
 

--- a/settei/version.py
+++ b/settei/version.py
@@ -1,6 +1,8 @@
 """:mod:`settei.version` --- Version data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 0.2.0
+
 """
 
 #: (:class:`typing.Tuple`\ [:class:`int`, :class:`int`, :class:`int`])

--- a/settei/version.py
+++ b/settei/version.py
@@ -5,7 +5,7 @@
 
 #: (:class:`typing.Tuple`\ [:class:`int`, :class:`int`, :class:`int`])
 #: The triple of version numbers e.g. ``(1, 2, 3)``.
-VERSION_INFO = (0, 3, 1)
+VERSION_INFO = (0, 4, 0)
 
 #: (:class:`str`) The version string e.g. ``'1.2.3'``.
 VERSION = '{}.{}.{}'.format(*VERSION_INFO)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -4,7 +4,7 @@ import warnings
 
 from pytest import mark, raises
 
-from settei.base import (Configuration, ConfigWarning,
+from settei.base import (ConfigKeyError, Configuration, ConfigWarning,
                          config_property, get_union_types)
 
 
@@ -77,7 +77,7 @@ def test_config_property(union_value: typing.Union[int, str]):
 
 def test_config_property_absence():
     c = TestConfig()
-    with raises(KeyError):
+    with raises(ConfigKeyError):
         c.depth1_required
     with warnings.catch_warnings(record=True) as w:
         assert c.depth1_optional == ''
@@ -93,7 +93,7 @@ def test_config_property_absence():
         assert c.depth1_default_func_warn == ''
         assert len(w) == 1
         assert issubclass(w[-1].category, ConfigWarning)
-    with raises(KeyError):
+    with raises(ConfigKeyError):
         c.depth2_required
     with warnings.catch_warnings(record=True) as w:
         assert c.depth2_optional is None
@@ -102,13 +102,13 @@ def test_config_property_absence():
         assert c.depth2_warn is None
         assert len(w) == 1
         assert issubclass(w[-1].category, ConfigWarning)
-    with raises(KeyError):
+    with raises(ConfigKeyError):
         c.union
 
 
 def test_config_property_absence_2nd_depth():
     c = TestConfig(section={})
-    with raises(KeyError):
+    with raises(ConfigKeyError):
         c.depth2_required
     with warnings.catch_warnings(record=True) as w:
         assert c.depth2_optional is None

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -4,7 +4,8 @@ import warnings
 
 from pytest import mark, raises
 
-from settei.base import (ConfigKeyError, Configuration, ConfigWarning,
+from settei.base import (ConfigKeyError, ConfigTypeError,
+                         Configuration, ConfigWarning,
                          config_property, get_union_types)
 
 
@@ -117,6 +118,17 @@ def test_config_property_absence_2nd_depth():
         assert c.depth2_warn is None
         assert len(w) == 1
         assert issubclass(w[-1].category, ConfigWarning)
+
+
+def test_config_property_type_error():
+    c = TestConfig(key='not an integer')
+    with raises(ConfigTypeError):
+        c.depth1_required
+    c2 = TestConfig()
+    assert isinstance(c2.depth1_optional, str), \
+        'default should be possible to bypass typecheck'
+    assert isinstance(c2.depth1_default_func, str), \
+        'default_func should be possible to bypass typecheck'
 
 
 def test_app_from_file(tmpdir):


### PR DESCRIPTION
**This change depends on PR #17.  Please review #17 prior to this.**

Replaced `KeyError` and `TypeError` with `ConfigKeyError` and `ConfigTypeError` to distinguish them from ordinary errors raised by Python's built-in functions.