### PR TITLE
Add support for enum conversion

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,10 @@ Version 0.5.2
 
 To be released.
 
+- Enabled declaring :class:`enum.Enum` types in :class:`~settei.config_proprety`. [`#29`_]
+
+.. _#29: https://github.com/spoqa/settei/pull/29 
+
 
 Version 0.5.1
 -------------

--- a/settei/base.py
+++ b/settei/base.py
@@ -150,12 +150,11 @@ class config_property:
                 raise ConfigKeyError(key)
         return False, value
 
-    def convert_native_type(self, value) -> object:
-        union_types = get_union_types(self.cls)
-        cls = self.cls if union_types is None else union_types
+    def convert_native_type(self, value) -> typing.Any:
+        cls = get_union_types(self.cls) or self.cls
         if isinstance(cls, type) and issubclass(cls, enum.Enum):
             try:
-                return cls(str(value))
+                return cls(value)
             except ValueError:
                 raise ConfigTypeError(
                     'Invalid value {0} in {1!r}. Candidates are: {2}'.format(
@@ -168,7 +167,7 @@ class config_property:
             candidates = []
             for e in enums:
                 try:
-                    candidates.append(e(str(value)))
+                    candidates.append(e(value))
                 except ValueError:
                     pass
             if len(candidates) == 0:

--- a/settei/base.py
+++ b/settei/base.py
@@ -170,7 +170,7 @@ class config_property:
                     candidates.append(e(value))
                 except ValueError:
                     pass
-            if len(candidates) == 0:
+            if not candidates:
                 if non_enums:
                     return value
                 else:

--- a/settei/base.py
+++ b/settei/base.py
@@ -94,7 +94,7 @@ class config_property:
     """
 
     @typechecked
-    def __init__(self, key: str, cls, docstring: str=None, **kwargs) -> None:
+    def __init__(self, key: str, cls, docstring: str = None, **kwargs) -> None:
         self.key = key
         self.cls = cls
         self.__doc__ = docstring
@@ -121,7 +121,7 @@ class config_property:
             self.default_func = None
             self.default_warning = False
 
-    def __get__(self, obj, cls: typing.Optional[type]=None):
+    def __get__(self, obj, cls: typing.Optional[type] = None):
         if obj is None:
             return self
         default, value = self.get_raw_value(obj)
@@ -322,12 +322,12 @@ class config_object_property(config_property):
     )
 
     @typechecked
-    def __init__(self, key: str, cls, docstring: str=None, recurse: bool=False,
-                 **kwargs) -> None:
+    def __init__(self, key: str, cls, docstring: str = None,
+                 recurse: bool = False, **kwargs) -> None:
         super().__init__(key=key, cls=cls, docstring=docstring, **kwargs)
         self.recurse = recurse
 
-    def __get__(self, obj, cls: typing.Optional[type]=None):
+    def __get__(self, obj, cls: typing.Optional[type] = None):
         if obj is None:
             return self
         default, expression = self.get_raw_value(obj)
@@ -473,7 +473,7 @@ class Configuration(collections.abc.Mapping):
             return cls.from_file(f)
 
     @typechecked
-    def __init__(self, config: typing.Mapping[str, object]={}, **kwargs):
+    def __init__(self, config: typing.Mapping[str, object] = {}, **kwargs):
         self.config = dict(config, **kwargs)
 
     def __len__(self) -> int:

--- a/settei/presets/celery.py
+++ b/settei/presets/celery.py
@@ -62,8 +62,8 @@ class WorkerConfiguration(LoggingConfiguration):
     @cached_property
     def worker_schedule(self) -> typing.Mapping[str,
                                                 typing.Mapping[str, object]]:
-        """(:class:`typing.Mapping`\ [:class:`str`,
-        :class:`typing.Mapping`\ [:class:`str`, :class:`object`]])
+        """(:class:`typing.Mapping`\\ [:class:`str`,
+        :class:`typing.Mapping`\\ [:class:`str`, :class:`object`]])
         The schedule table for Celery Beat, scheduler for periodic tasks.
 
         There's some preprocessing before reading configuration.
@@ -162,7 +162,7 @@ class WorkerConfiguration(LoggingConfiguration):
 
     @cached_property
     def worker_config(self) -> typing.Mapping[str, object]:
-        """(:class:`typing.Mapping`\ [:class:`str`, :class:`object`])
+        """(:class:`typing.Mapping`\\ [:class:`str`, :class:`object`])
         The configuration maping for worker that will go to :attr:`Celery.conf
         <celery.Celery.conf>`.
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -59,7 +59,7 @@ class TestConfig(dict):
 
 class EnumTestConfig(dict):
     enum = config_property('enum', Enum1, default=Enum1.apple)
-    enum_union = config_property('enum_union', typing.Union[Enum1, Enum2])
+    enum_union = config_property('enum_union', typing.Union[Enum1, Enum2, str])
 
 
 class TestAppConfig(Configuration):
@@ -99,14 +99,18 @@ def test_enum_config_property():
     c1 = EnumTestConfig(enum='apple', enum_union='banana')
     c2 = EnumTestConfig(enum='banana', enum_union='candy')
     c3 = EnumTestConfig(enum='dragonfruit', enum_union='apple')
+    c4 = EnumTestConfig(enum='cherry', enum_union='foo')
     assert c1.enum == Enum1.apple
     assert c2.enum == Enum1.banana
     assert c1.enum_union == Enum1.banana
     assert c2.enum_union == Enum2.candy
-    with raises(ConfigTypeError):
+    with raises(ConfigTypeError) as ex:
         c3.enum
-    with raises(ConfigTypeError):
+    assert ex.value.args[0] == 'Invalid value dragonfruit in <enum \'Enum1\'>. Candidates are: apple, banana, cherry'  # noqa
+    with raises(ConfigTypeError) as ex:
         c3.enum_union
+    assert ex.value.args[0] == 'Ambiguous enum type for value apple: <Enum1.apple: \'apple\'>, <Enum2.apple: \'apple\'>'  # noqa
+    assert c4.enum_union == 'foo'
 
 
 def test_config_property_absence():

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,3 +1,4 @@
+import enum
 import pathlib
 import typing  # noqa
 import warnings
@@ -8,6 +9,18 @@ from settei.base import (ConfigKeyError, ConfigTypeError,
                          Configuration, ConfigValueError, ConfigWarning,
                          config_object_property, config_property,
                          get_union_types)
+
+
+class Enum1(enum.Enum):
+    apple = 'apple'
+    banana = 'banana'
+    cherry = 'cherry'
+
+
+class Enum2(enum.Enum):
+    apple = 'apple'
+    bear = 'bear'
+    candy = 'candy'
 
 
 def test_get_union_types():
@@ -44,6 +57,11 @@ class TestConfig(dict):
     union = config_property('union', typing.Union[int, str])
 
 
+class EnumTestConfig(dict):
+    enum = config_property('enum', Enum1, default=Enum1.apple)
+    enum_union = config_property('enum_union', typing.Union[Enum1, Enum2])
+
+
 class TestAppConfig(Configuration):
     database_url = config_property(
         'database.url', str,
@@ -75,6 +93,20 @@ def test_config_property(union_value: typing.Union[int, str]):
         assert c.depth2_warn == 'val'
         assert len(w) == 0
     assert c.union == union_value
+
+
+def test_enum_config_property():
+    c1 = EnumTestConfig(enum='apple', enum_union='banana')
+    c2 = EnumTestConfig(enum='banana', enum_union='candy')
+    c3 = EnumTestConfig(enum='dragonfruit', enum_union='apple')
+    assert c1.enum == Enum1.apple
+    assert c2.enum == Enum1.banana
+    assert c1.enum_union == Enum1.banana
+    assert c2.enum_union == Enum2.candy
+    with raises(ConfigTypeError):
+        c3.enum
+    with raises(ConfigTypeError):
+        c3.enum_union
 
 
 def test_config_property_absence():

--- a/tests/presets/logging_test.py
+++ b/tests/presets/logging_test.py
@@ -21,8 +21,8 @@ def has_handlers(logger: logging.Logger) -> bool:
     return False
 
 
-def test_configure_logging(prefix: str='settei.tests.',
-                           conf_cls: type=LoggingConfiguration):
+def test_configure_logging(prefix: str = 'settei.tests.',
+                           conf_cls: type = LoggingConfiguration):
     TestHandler.records = []
     a = logging.getLogger(prefix + 'a')
     b = logging.getLogger(prefix + 'b')


### PR DESCRIPTION
This changes allow settei to being able to declare [Python 3 enumerations](https://docs.python.org/3/library/enum.html) in `config_property`.

```python
class Animal(enum.Enum):
    dog = 'dog'
    cat = 'cat'

class MyConfig(dict):
    animal_preference = config_property('animal.preference', Animal)

config = MyConfig(animal={'preference': 'dog'})
assert config.animal_preference is Animal.dog
```