### PR TITLE
Hooks List feature

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,8 +7,11 @@ Version 0.5.2
 To be released.
 
 - Enabled declaring :class:`enum.Enum` types in :class:`~settei.config_proprety`. [`#29`_]
+- Add hooks list feature for :attr:`~settei.presets.flask.WebConfiguration.on_web_loaded` and
+  :attr:`~settei.presets.celery.WorkerConfiguration.on_worker_loaded`. [`#30`_]
 
-.. _#29: https://github.com/spoqa/settei/pull/29 
+.. _#29: https://github.com/spoqa/settei/pull/29
+.. _#30: https://github.com/spoqa/settei/pull/30
 
 
 Version 0.5.1

--- a/settei/base.py
+++ b/settei/base.py
@@ -161,7 +161,7 @@ class config_property:
                         value, cls, ', '.join(cls.__members__)
                     )
                 )
-        elif isinstance(cls, collections.Iterable):
+        elif isinstance(cls, collections.abc.Iterable):
             enums = filter(lambda i: issubclass(i, enum.Enum), cls)
             non_enums = filter(lambda i: not issubclass(i, enum.Enum), cls)
             candidates = []

--- a/settei/presets/celery.py
+++ b/settei/presets/celery.py
@@ -231,6 +231,9 @@ class WorkerConfiguration(LoggingConfiguration):
         :param app: a ready celery app
         :type app: :class:`celery.Celery`
 
+        .. versionchanged:: 0.5.2
+           Hooks list added
+
         """
         self.configure_logging()
 

--- a/settei/presets/flask.py
+++ b/settei/presets/flask.py
@@ -7,17 +7,37 @@
 import collections.abc
 import typing
 
+from flask import Flask
 from typeguard import typechecked
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.utils import cached_property
 
 from ..base import config_property
+from ..utils import import_hook
 from .logging import LoggingConfiguration
 
 __all__ = 'WebConfiguration',
 
 
 class WebConfiguration(LoggingConfiguration):
+    """Settei configuration for the `Flask`_. For more information, See the
+    example below:
+
+    .. code-block:: python
+
+       config = WebConfiguration.from_path('config.toml')
+       app = Flask(__name__)
+       app.config.update(config.web_config)
+
+       @app.before_first_request
+       def before_first_request():
+           config.on_web_loaded(app)
+
+       app.run()
+
+    .. _Flask: http://flask.pocoo.org/
+
+    """
 
     web_debug = config_property(
         'web.debug', bool,
@@ -41,14 +61,68 @@ class WebConfiguration(LoggingConfiguration):
         return ImmutableDict((k.upper(), v) for k, v in web_config.items())
 
     @typechecked
-    def on_web_loaded(self, app: typing.Callable[..., typing.Any]):
-        """Be invoked when a WSGI app is ready.
+    def on_web_loaded(self, app: Flask):
+        """Trigger the ``web.on_loaded`` hooks.
+        You should invoke this function when the WSGI app is ready
+        with the WSGI app as argument.
+        You may want to use :attr:`flask.Flask.before_first_request`.
+
+        ``web.on_loaded`` hook can be a Python code or list of module path.
+
+        When ``web.on_loaded`` is a single string, it will be interpreted as
+        Python code.
+        The configuration and the WSGI app is injected as ``self`` and ``app``
+        each:
+
+        .. code-block:: toml
+
+           [web]
+           on_loaded = \"""
+           print('Hello, world!')
+           print('self is configuration!: {}'.format(self))
+           print('app is flask app!: {}'.format(app))
+           \"""
+
+
+        When ``web.on_loaded`` is a list of string, it will be interpreted as
+        module paths:
+
+        .. code-block:: toml
+
+           [web]
+           on_loaded = [
+               "utils.hooks:sample_hook",
+               "src.main:print_hello_world",
+           ]
+
+        The hooks must receive two arguments, :class:`Configuration` and
+        :class:`flask.Flask`:
+
+        .. code-block:: python
+
+           def sample_hook(conf: Configuration, app: Flask):
+               print('Hello, world!')
+               print('conf is configuration!: {}'.format(conf))
+               print('app is flask app!: {}'.format(app))
 
         :param app: a ready wsgi/flask app
-        :type app: :class:`flask.Flask`, :class:`typing.Callable`
+        :type app: :class:`flask.Flask`
 
         """
         self.configure_logging()
-        exec(self.config.get('web', {}).get('on_loaded', ''),
-             None,
-             {'self': self, 'app': app})
+
+        on_loaded = self.config.get('web', {}).get('on_loaded', [])
+
+        if isinstance(on_loaded, (list, tuple)):
+            for hook_path in on_loaded:
+                func = import_hook(hook_path)
+                func(self, app)
+        else:
+            exec(
+                on_loaded,
+                None,
+                {
+                    'self': self,
+                    'app': app
+                },
+            )

--- a/settei/presets/flask.py
+++ b/settei/presets/flask.py
@@ -108,6 +108,9 @@ class WebConfiguration(LoggingConfiguration):
         :param app: a ready wsgi/flask app
         :type app: :class:`flask.Flask`
 
+        .. versionchanged:: 0.5.2
+           Hooks list added
+
         """
         self.configure_logging()
 

--- a/settei/utils.py
+++ b/settei/utils.py
@@ -1,0 +1,14 @@
+import importlib
+
+
+def import_hook(module_path: str):
+    parts = module_path.split(':', 1)
+    if len(parts) == 1:
+        module_name, func_name = module_path, "main"
+    else:
+        module_name, func_name = parts[0], parts[1]
+
+    module = importlib.import_module(module_name)
+    func = getattr(module, func_name)
+
+    return func

--- a/tests/presets/logging_test.py
+++ b/tests/presets/logging_test.py
@@ -29,7 +29,7 @@ def test_configure_logging(prefix: str = 'settei.tests.',
     c = logging.getLogger(prefix + 'c')
 
     def log():
-        for level in 'debug', 'info', 'warn', 'error':
+        for level in 'debug', 'info', 'warning', 'error':
             for v, l in [('a', a), ('b', b), ('c', c)]:
                 getattr(l, level)('%s %s', level, v)
     assert not has_handlers(a)
@@ -65,9 +65,9 @@ def test_configure_logging(prefix: str = 'settei.tests.',
     assert has_handlers(c)
     log()
     assert TestHandler.records == [
-        'warn a',
-        'warn b',
-        'warn c',
+        'warning a',
+        'warning b',
+        'warning c',
         'error a',
         'error b',
         'error c',


### PR DESCRIPTION
Add a 'hooks list' feature on `on_web_loaded` of `WebConfiguration` and `on_worker_loaded` of `WorkerConfiguration`

- Reword documentation for `on_web_loaded` and `on_worker_loaded`
  - Make it clearly stating that the programmer should call `on_*_loaded` function when the app or worker loaded.
  - Add more details
- Implement hooks list feature (see below for detail)
  - Add tests for hooks list feature
  - Add documentation and examples for hooks list feature
- Add `typeguard` decorator to `on_worker_loaded` for keeping consistency with `on_web_loaded`
- Change parameter type of `on_web_loaded` to `Flask` from `typing.Callable[..., typing.Any]`
  - Rewrite tests of `on_web_loaded` to use `Flask` class instead of `lambda` to pass `typecheck`

## Hooks list feature

I think writing python code in the toml configuration file directly seems bad practice. So I wanted to add ways to hook python functions.

For backward compatibility, if the `on_loaded` configuration is a string, it will be interpreted as python code and executed with `self` and `app` injected.

When the `on_loaded` configuration is a list of string, each string will be interpreted as a path to a hook function. And the hook function will be executed with two arguments, the configuration itself and the app (`Flask` or `Celery` depends on the configuration type).

### Example

`utils/hooks.py`:

```python
...
def sample_hook(conf: WebConfiguration, app: Flask):
	print('Hello, world!')
	print('conf: {}, app: {}'.format(conf, app))
...
```

`config.toml`:

```toml
[web]
on_loaded = ["utils.hooks:sample_hook"]
```
