### PR TITLE
Change `app` argument type of `on_web_loaded` to `typing.Callable`

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,10 @@ Version 0.5.3
 
 To be released.
 
+- Change the ``app`` argument type of :attr:`~settei.presets.flask.WebConfiguration.on_web_loaded`
+  to :class:`typing.Callable` from :class:`flask.Flask`. [`#31`_]
+
+.. _#31: https://github.com/spoqa/settei/pull/31
 
 Version 0.5.2
 -------------

--- a/settei/presets/flask.py
+++ b/settei/presets/flask.py
@@ -7,7 +7,6 @@
 import collections.abc
 import typing
 
-from flask import Flask
 from typeguard import typechecked
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.utils import cached_property
@@ -61,7 +60,7 @@ class WebConfiguration(LoggingConfiguration):
         return ImmutableDict((k.upper(), v) for k, v in web_config.items())
 
     @typechecked
-    def on_web_loaded(self, app: Flask):
+    def on_web_loaded(self, app: typing.Callable[..., typing.Any]):
         """Trigger the ``web.on_loaded`` hooks.
         You should invoke this function when the WSGI app is ready
         with the WSGI app as argument.
@@ -106,10 +105,13 @@ class WebConfiguration(LoggingConfiguration):
                print('app is flask app!: {}'.format(app))
 
         :param app: a ready wsgi/flask app
-        :type app: :class:`flask.Flask`
+        :type app: :class:`flask.Flask`, :class:`typing.Callable`
 
         .. versionchanged:: 0.5.2
            Hooks list added
+
+        .. versionchanged:: 0.5.3
+           Change the ``app`` argument type to :class:`typing.Callable`
 
         """
         self.configure_logging()

--- a/tests/presets/flask_test.py
+++ b/tests/presets/flask_test.py
@@ -59,5 +59,16 @@ def test_web_on_loaded_hooks_list():
     assert app.name == 'ok'
 
 
+def test_web_on_loaded_with_callable():
+    conf = WebConfiguration({
+        'web': {
+            'on_loaded': "assert app(self) == 'ok'",
+        },
+    })
+    log = []
+    conf.on_web_loaded(lambda self: log.append(self) or 'ok')
+    assert log == [conf]
+
+
 def test_configure_logging():
     configure_test('settei.webtest.', WebConfiguration)


### PR DESCRIPTION
In the previous PR (#30), I've changed the type of `app` argument of `on_web_loaded` to `flask.Flask` from `typing.Callable[..., typing.Any]`.
I thought the `typing.Callable` type was a workaround for testing, but I later found that this was the intended feature for WSGI apps.

I also met some use-cases that are actually failing with settei 0.5.2 with the above reason. So I made this quick-fix

## Changes

- `settei/preset/flask.py`
  - From

    ```python
    def on_web_loaded(self, app: Flask):
    ```

  - To

    ```python
    def on_web_loaded(self, app: typing.Callable[..., typing.Any]):
    ```

- `tests/preset/flask_test.py`
  - Add a regression test
- Add documentation about changes

## Concern

In #30, I've also added `@typechecked` decorator to `WorkerConfiguration.on_worker_loaded`. May this change cause another issue?