### PR TITLE
Fix broken `default` option

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,8 +4,11 @@ Changelog
 Version 0.5.5
 -------------
 
+- Fix ``default`` option of :class:`~settei.base.config_object_property`. [`#34`_]
+
 To be released.
 
+.. _#34: https://github.com/spoqa/settei/pull/34
 
 Version 0.5.4
 -------------

--- a/settei/base.py
+++ b/settei/base.py
@@ -79,10 +79,6 @@ class config_property:
                             this option is only available when ``default``
                             value is provided
     :type default_warning: :class:`bool`
-    :type cached: :class:`bool`
-    :param cached: keyword only argument.
-                   get config value which is cached on its instance so that
-                   config value won't be created again.
 
     .. versionchanged:: 0.4.0
 
@@ -99,11 +95,9 @@ class config_property:
 
     @typechecked
     def __init__(self, key: str, cls, docstring: str = None,
-                 *, cached: bool = False, default_warning: bool = False,
-                 **kwargs) -> None:
+                 *, default_warning: bool = False, **kwargs) -> None:
         self.key = key
         self.cls = cls
-        self.cached = cached
         self.__doc__ = docstring
         if 'default_func' in kwargs:
             if 'default' in kwargs:
@@ -314,11 +308,18 @@ class config_object_property(config_property):
                             this option is only available when ``default``
                             value is provided
     :type default_warning: :class:`bool`
+    :type cached: :class:`bool`
+    :param cached: keyword only argument.
+                   get config value which is cached on its instance so that
+                   config value won't be created again.
 
     .. versionadded:: 0.4.0
 
     .. versionadded:: 0.5.0
        The ``recurse`` option.
+
+    .. versionadded:: 0.5.5
+       The ``cached`` option.
 
     """
 
@@ -330,9 +331,11 @@ class config_object_property(config_property):
 
     @typechecked
     def __init__(self, key: str, cls, docstring: str = None,
-                 recurse: bool = False, **kwargs) -> None:
+                 recurse: bool = False, *, cached: bool = False,
+                 **kwargs) -> None:
         super().__init__(key=key, cls=cls, docstring=docstring, **kwargs)
         self.recurse = recurse
+        self.cached = cached
 
     def default_check(self, default, expression, obj):
         if not default:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -194,6 +194,9 @@ class TestAppConfigObject(Configuration):
     recursive = config_object_property('sample.c', SampleInterface,
                                        recurse=True)
     cached = config_object_property('sample.a', SampleInterface, cached=True)
+    cached_with_default = config_object_property('sample.b', SampleInterface,
+                                                 default=Impl('default'),
+                                                 cached=True)
 
 
 def test_config_object_property():
@@ -228,6 +231,10 @@ def test_config_object_property():
         },
     }
     assert c.no_default is not c.no_default
+    vv = c.with_default
+    assert isinstance(vv, Impl)
+    assert vv.args == ('default',)
+    assert vv.kwargs == {}
 
 
 def test_config_object_property_recurse():
@@ -332,6 +339,17 @@ def test_app_from_path(tmpdir):
 
 def test_config_object_property_cached():
     c = TestAppConfigObject(sample={
-        'a': {'class': __name__ + ':Impl'},
+        'a': {
+            'class': __name__ + ':Impl',
+            '*': ['a', 'b', 'c'],
+            'd': 4,
+            'e': 5,
+        },
     })
     assert c.cached is c.cached
+    assert isinstance(c.cached, Impl)
+    assert c.cached.args == ('a', 'b', 'c')
+    assert c.cached.kwargs == {'d': 4, 'e': 5}
+    assert isinstance(c.cached_with_default, Impl)
+    assert c.cached_with_default.args == ('default',)
+    assert c.cached_with_default.kwargs == {}


### PR DESCRIPTION
`config_object_property` 에서 `default` 옵션을 켜면 `object` 가 아니고 `(True, object)` 가 리턴되는 버그를 수정합니다.