### PR TITLE
Look up OS environment variable

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,10 @@ Version 0.5.6
 
 To be released.
 
+- Added ``lookup_env`` option to :class:`~settei.base.config_property`.
+  It gives you the way to read OS environment variable on settei. [`#35`_]
+
+.. _#35: https://github.com/spoqa/settei/pull/35
 
 Version 0.5.5
 -------------

--- a/settei/base.py
+++ b/settei/base.py
@@ -178,7 +178,7 @@ class config_property:
             env_val = os.environ.get(
                 self.env_name or self.key.replace('.', '_').upper()
             )
-            if env_val:
+            if env_val is not None:
                 if self.parse_env:
                     try:
                         env_val = self.parse_env(env_val)

--- a/settei/parse_env.py
+++ b/settei/parse_env.py
@@ -1,0 +1,57 @@
+""":mod:`settei.parse_env` --- Utility function to parse an environment vars.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.5.6
+
+"""
+import uuid
+
+from typeguard import typechecked
+
+__all__ = 'parse_bool', 'parse_float', 'parse_uuid'
+
+
+@typechecked
+def parse_bool(v: str) -> bool:
+    """Parse boolean type. It returns ``True``
+    when ``v`` is in one of the following values (``'y'``, ``'yes'``, ``'t'``,
+    ``'true'``, `'1'`).
+
+    .. note::
+
+       Since it tries to parse a value into lowercase, ``'Yes'``, ``'True'``,
+       ``'Y'`` represent ``True`` as well. (even ``'yEs'``, ``'YeS'`` ...)
+
+    :param v: An environment variable to parse.
+    :type v: :class:`str`
+
+    .. versionadded:: 0.5.6
+
+    """
+    return v.lower() in ('y', 'yes', 't', 'true', '1')
+
+
+@typechecked
+def parse_float(v: str) -> float:
+    """Parse float type.
+
+    :param v: An environment variable to parse.
+    :type v: :class:`str`
+
+    .. versionadded:: 0.5.6
+
+    """
+    return float(v)
+
+
+@typechecked
+def parse_uuid(v: str) -> uuid.UUID:
+    """Parse UUID type.
+
+    :param v: An environment variable to parse.
+    :type v: :class:`str`
+
+    .. versionadded:: 0.5.6
+
+    """
+    return uuid.UUID(v)

--- a/settei/parse_env.py
+++ b/settei/parse_env.py
@@ -8,7 +8,7 @@ import uuid
 
 from typeguard import typechecked
 
-__all__ = 'parse_bool', 'parse_float', 'parse_uuid'
+__all__ = 'parse_bool', 'parse_float', 'parse_int', 'parse_uuid'
 
 
 @typechecked
@@ -24,6 +24,8 @@ def parse_bool(v: str) -> bool:
 
     :param v: An environment variable to parse.
     :type v: :class:`str`
+    :return: A boolean type value
+    :rtype: :class:`bool`
 
     .. versionadded:: 0.5.6
 
@@ -37,6 +39,8 @@ def parse_float(v: str) -> float:
 
     :param v: An environment variable to parse.
     :type v: :class:`str`
+    :return: A float type value
+    :rtype: :class:`float`
 
     .. versionadded:: 0.5.6
 
@@ -45,11 +49,28 @@ def parse_float(v: str) -> float:
 
 
 @typechecked
+def parse_int(v: str) -> int:
+    """Parse int type.
+
+    :param v: An environment variable to parse.
+    :type v: :class:`str`
+    :return: A int type value
+    :rtype: :class:`int`
+
+    .. versionadded:: 0.5.6
+
+    """
+    return int(v)
+
+
+@typechecked
 def parse_uuid(v: str) -> uuid.UUID:
     """Parse UUID type.
 
     :param v: An environment variable to parse.
     :type v: :class:`str`
+    :return: A UUID type value
+    :rtype: :class:`uuid.UUID`
 
     .. versionadded:: 0.5.6
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -366,6 +366,7 @@ class TestEnvAppConfig(dict):
     given_first = config_property('foo.quuz', str, lookup_env=True)
     parse = config_property('foo.parse', bool,
                             lookup_env=True, parse_env=lambda x: x == 'True')
+    empty_text = config_property('foo.empty', str, lookup_env=True)
 
 
 def test_config_object_property_lookup_env():
@@ -373,6 +374,7 @@ def test_config_object_property_lookup_env():
     os.environ['LOREM_IPSUM'] = 'gg'
     os.environ['FOO_QUX'] = 'qux'
     os.environ['FOO_QUUZ'] = 'quuz'
+    os.environ['FOO_EMPTY'] = ''
     c = TestEnvAppConfig(foo={'quuz': 'gl'})
     assert c.env_lookup == 'hi', \
         'Get env var when given configuration is missing.'
@@ -386,6 +388,8 @@ def test_config_object_property_lookup_env():
     # no env, no configration = Error
     with raises(ConfigKeyError):
         c.env_error
+    # should allow empty text
+    assert c.empty_text == ''
 
 
 def test_config_object_property_convert_func():

--- a/tests/parse_env_test.py
+++ b/tests/parse_env_test.py
@@ -3,7 +3,7 @@ import uuid
 from pytest import mark
 from typeguard import typechecked
 
-from settei.parse_env import parse_bool, parse_float, parse_uuid
+from settei.parse_env import parse_bool, parse_float, parse_int, parse_uuid
 
 
 @mark.parametrize('v, result', [
@@ -27,6 +27,10 @@ def test_parse_bool(v: str, result: bool):
 
 def test_parse_float():
     assert parse_float('3.14') == float(3.14)
+
+
+def test_parse_int():
+    assert parse_int('1') == 1
 
 
 def test_parse_uuid():

--- a/tests/parse_env_test.py
+++ b/tests/parse_env_test.py
@@ -1,0 +1,34 @@
+import uuid
+
+from pytest import mark
+from typeguard import typechecked
+
+from settei.parse_env import parse_bool, parse_float, parse_uuid
+
+
+@mark.parametrize('v, result', [
+    ('y', True),
+    ('Y', True),
+    ('yes', True),
+    ('true', True),
+    ('t', True),
+    ('True', True),
+    ('1', True),
+    ('n', False),
+    ('foobar', False),
+    ('0', False),
+    ('f', False),
+    ('false', False),
+])
+@typechecked
+def test_parse_bool(v: str, result: bool):
+    assert parse_bool(v) == result
+
+
+def test_parse_float():
+    assert parse_float('3.14') == float(3.14)
+
+
+def test_parse_uuid():
+    expected = uuid.UUID('e05bf482-c18e-4e91-b079-45bbbd5cc03c')
+    assert parse_uuid('e05bf482-c18e-4e91-b079-45bbbd5cc03c') == expected


### PR DESCRIPTION
Look up os environment variable as well in `config_property`.

- Look up os environment variable using `key` by default. ( `foo.bar` is looking for `FOO_BAR` in environment variable.)
   - It can be access diffrent name if `env_name` is given.
- It is useful to parse an environment variable into python types. So `parse_env` argument wil do that for you!
   - It is unncessary to implement a parse function repeatedly. So i implement some utility functions.