### PR TITLE
Look up environment variable in config_object_property

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version 0.6.0
+-------------
+
+To be released.
+
+- Added ``lookup_env`` option to :class:`~settei.base.config_object_property`.
+  It giaves you the way to read OS environment variable like
+  :class:`~settei.base.config_property`. [`#37`_]
+
+.. _#37: https://github.com/spoqa/settei/pull/37
+
 Version 0.5.6
 -------------
 

--- a/settei/base.py
+++ b/settei/base.py
@@ -383,6 +383,35 @@ class config_object_property(config_property):
        CACHE__*__1 = "6379"
        CACHE__DB = "0"
 
+    You may want to parse an environment variable into appropriate
+    Python types. Give a function that takes one dict and return a new dict.
+
+    In the above example, it is good to be that if the port number and
+    db number are integer.
+
+    .. code-block:: python
+
+       def parse_cache(d: typing.Mapping) -> typing.Mapping:
+           return {
+               **d,
+               '*': [d['*'][0], int(d['*'][1])],
+               'db': int(d['db']),
+           }
+
+       class App(Configuration):
+           cache = config_object_property('cache', BaseCache, lookup_env=True,
+                                          parse=parse_cache)
+
+    .. note::
+
+       dict destructing onnly support in Python 3.5+. You need to
+       ``dict.copy()`` and ``dict.upate()`` in Python 3.4.
+
+       ```
+       result = d.copy()
+       result.update({'foo': ...})
+       ```
+
     :param key: the dotted string of key path.  for example ``abc.def`` looks
                 up ``config['abc']['def']``
     :type key: :class:`str`
@@ -447,7 +476,7 @@ class config_object_property(config_property):
     def __init__(self, key: str, cls, docstring: str = None,
                  recurse: bool = False, *, cached: bool = False,
                  lookup_env: bool = True,
-                 parse: ParseFunctionType = None,
+                 parse: typing.Optional[ParseFunctionType] = None,
                  **kwargs) -> None:
         super().__init__(key=key, cls=cls, docstring=docstring,
                          lookup_env=lookup_env, **kwargs)

--- a/settei/base.py
+++ b/settei/base.py
@@ -455,7 +455,9 @@ class config_object_property(config_property):
         self.recurse = recurse
         self.cached = cached
 
-    def _transform_env_to_dict(self, env):
+    def _transform_env_to_dict(
+        self, env: typing.Mapping[str, str]
+    ) -> typing.Mapping:
         """Transform environment variable into a configuration dict. It uses
         ``delimiter`` to decide the form of result.
 

--- a/settei/version.py
+++ b/settei/version.py
@@ -7,7 +7,7 @@
 
 #: (:class:`typing.Tuple`\ [:class:`int`, :class:`int`, :class:`int`])
 #: The triple of version numbers e.g. ``(1, 2, 3)``.
-VERSION_INFO = (0, 5, 7)
+VERSION_INFO = (0, 6, 0)
 
 #: (:class:`str`) The version string e.g. ``'1.2.3'``.
 VERSION = '{}.{}.{}'.format(*VERSION_INFO)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -357,11 +357,12 @@ def test_config_object_property_cached():
 
 
 def parse_foo(d: typing.Mapping[str, str]):
-    return {
-        **d,
+    r = d.copy()
+    r.update({
         '*': [int(x) for x in d['*'][0]],
         'foo': float(d['foo']),
-    }
+    })
+    return r
 
 
 class TestEnvAppConfig(dict):

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -367,14 +367,19 @@ class TestEnvAppConfig(dict):
     parse = config_property('foo.parse', bool,
                             lookup_env=True, parse_env=lambda x: x == 'True')
     empty_text = config_property('foo.empty', str, lookup_env=True)
+    env_object = config_object_property('foo.obj', SampleInterface)
+    recursiveobj = config_object_property('foo.recurse', SampleInterface,
+                                          recurse=True)
+
+    # recursive = config_object_property('foo.DD_DD', SampleInterface)
 
 
-def test_config_object_property_lookup_env():
-    os.environ['FOO_BAR'] = 'hi'
+def test_config_property_lookup_env():
+    os.environ['FOO__BAR'] = 'hi'
     os.environ['LOREM_IPSUM'] = 'gg'
-    os.environ['FOO_QUX'] = 'qux'
-    os.environ['FOO_QUUZ'] = 'quuz'
-    os.environ['FOO_EMPTY'] = ''
+    os.environ['FOO__QUX'] = 'qux'
+    os.environ['FOO__QUUZ'] = 'quuz'
+    os.environ['FOO__EMPTY'] = ''
     c = TestEnvAppConfig(foo={'quuz': 'gl'})
     assert c.env_lookup == 'hi', \
         'Get env var when given configuration is missing.'
@@ -392,9 +397,46 @@ def test_config_object_property_lookup_env():
     assert c.empty_text == ''
 
 
-def test_config_object_property_convert_func():
-    os.environ['FOO_PARSE'] = 'True'
+def test_config_property_convert_func():
+    os.environ['FOO__PARSE'] = 'True'
     c = TestEnvAppConfig(foo={})
     assert c.parse
-    os.environ['FOO_PARSE'] = 'False'
+    os.environ['FOO__PARSE'] = 'False'
     assert not c.parse
+
+
+def test_config_object_property_env():
+    os.environ['FOO__OBJ__CLASS'] = __name__ + ':Impl'
+    os.environ['FOO__OBJ__FOO'] = 'foo'
+    os.environ['FOO__OBJ__BAR'] = 'bar'
+    c = TestEnvAppConfig(foo={})
+    assert c.env_object.kwargs == {
+        'foo': 'foo',
+        'bar': 'bar',
+    }
+
+
+def test_config_object_property_env_recurse():
+    os.environ['FOO__RECURSE__CLASS'] = __name__ + ':Impl'
+    os.environ['FOO__RECURSE__*__0'] = 'lorem'
+    os.environ['FOO__RECURSE__F__CLASS'] = __name__ + ':Impl'
+    os.environ['FOO__RECURSE__F__NESTED'] = 'true'
+    os.environ['FOO__RECURSE__F__RECURSIVE__CLASS'] = __name__ + ':Impl'
+    os.environ['FOO__RECURSE__F__RECURSIVE__NESTED'] = 'true'
+    os.environ['FOO__RECURSE__F__RECURSIVE__*__0'] = 'hi'
+    os.environ['FOO__RECURSE__F__RECURSIVE__*__1'] = 'mi'
+    os.environ['FOO__RECURSE__F__RECURSIVE__*__2'] = 'me'
+    c = TestEnvAppConfig(foo={})
+    v = c.recursiveobj
+    assert isinstance(v, Impl)
+    assert frozenset(v.kwargs) == frozenset({'f'})
+    assert v.args == ('lorem', )
+    f = v.kwargs['f']
+    assert isinstance(f, Impl)
+    assert f.args == ()
+    assert frozenset(f.kwargs) == frozenset({'nested', 'recursive'})
+    assert f.kwargs['nested'] == 'true'
+    r = f.kwargs['recursive']
+    assert isinstance(r, Impl)
+    assert r.args == ('hi', 'mi', 'me')
+    assert r.kwargs == {'nested': 'true'}


### PR DESCRIPTION
After https://github.com/spoqa/settei/pull/35, we had to add feature for reading an environment variable in `config_object_property` as well as `config_property`.

- Renamed the delimiter ( `_` → `__`): Unlike settei version 0.5.6, it has to split environment variable name into key. So i renamed it for the users who want to make their's variable name with `_`.
- Added parse function: There could be multiple arguments and keywords in `config_object_property`. So parse function of `config_object_property` takes only 1 parameter which is `dict` data of configuration, and it has to return a dict that has parsed a data.
- Custom environment name is not allowed: I think making the allowing the custom environment name gives too many complexity on settei's code. So i decide not to add this feature.

@pbzweihander @ClaudeSeo @Jhuni0123 Review please!

