### PR TITLE
Introduce new feature for environment variable

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ To be released.
   :class:`~settei.base.config_object_property`.
 - Changed asterisk charater into ``ASTERISK``. We couldn't use special
   charaters in OS environment variable name.
+- Support list in environment variable.
 
 Version 0.6.0
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,9 @@ Version 0.7.0
 
 To be released.
 
+- Removed ``env_name`` paramter from
+  :class:`~settei.base.config_object_property`.
+
 Version 0.6.0
 -------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Version 0.6.1
+Version 0.7.0
 -------------
 
 To be released.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,9 @@ To be released.
 - Changed asterisk charater into ``ASTERISK``. We couldn't use special
   charaters in OS environment variable name.
 - Support list in environment variable.
+- Allow configure value on both toml and environment variable at
+  the same time.  Firstly settei get a configuration from toml,
+  then scan an environment variable.
 
 Version 0.6.0
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,8 @@ To be released.
 
 - Removed ``env_name`` paramter from
   :class:`~settei.base.config_object_property`.
+- Changed asterisk charater into ``ASTERISK``. We couldn't use special
+  charaters in OS environment variable name.
 
 Version 0.6.0
 -------------

--- a/settei/base.py
+++ b/settei/base.py
@@ -84,11 +84,6 @@ class config_property:
     :param lookup_env: whether to look up a value in environment variable
                        when the configuration value is not given.
     :type lookup_env: :class:`bool`
-    :param env_name: A name of an environment variable of configuration.
-                     as a default, it looks up a value by using :param key:.
-                     for example ``abc.def`` looks up the environment variable
-                     ``ABC__DEF``.
-    :type env_name: :class:`str`
     :param parse_env: Since environment variable is string on Python, It needs
                       to parse its value to use configuration.
                       A function that takes an 1 positional argument should be
@@ -124,20 +119,19 @@ class config_property:
     """
 
     delimiter = '__'
+    ASTERISK_CHAR = 'ASTERISK'
 
     @typechecked
     def __init__(self, key: str, cls, docstring: str = None,
                  *,
                  default_warning: bool = False,
                  lookup_env: bool = True,
-                 env_name: typing.Optional[str] = None,
                  parse_env: typing.Callable[[str, ], typing.Any] = None,
                  **kwargs) -> None:
         self.key = key
         self.cls = cls
         self.__doc__ = docstring
         self.lookup_env = lookup_env
-        self.env_name = env_name
         self.parse_env = parse_env
         if 'default_func' in kwargs:
             if 'default' in kwargs:
@@ -184,9 +178,7 @@ class config_property:
         return k.replace('.', self.delimiter).upper()
 
     def _value_from_env(self, obj):
-        env_val = os.environ.get(
-            self.env_name or self._make_env_name(self.key)
-        )
+        env_val = os.environ.get(self._make_env_name(self.key))
         if env_val is None:
             return env_val
         if self.parse_env:

--- a/settei/version.py
+++ b/settei/version.py
@@ -7,7 +7,7 @@
 
 #: (:class:`typing.Tuple`\ [:class:`int`, :class:`int`, :class:`int`])
 #: The triple of version numbers e.g. ``(1, 2, 3)``.
-VERSION_INFO = (0, 6, 1)
+VERSION_INFO = (0, 7, 0)
 
 #: (:class:`str`) The version string e.g. ``'1.2.3'``.
 VERSION = '{}.{}.{}'.format(*VERSION_INFO)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -368,8 +368,6 @@ def parse_foo(d: typing.Mapping[str, str]):
 class TestEnvAppConfig(dict):
 
     env_lookup = config_property('foo.bar', str, lookup_env=True)
-    env_with_name = config_property('foo.baz', str, lookup_env=True,
-                                    env_name='LOREM_IPSUM')
     env_false = config_property('foo.qux', str, lookup_env=False)
     env_error = config_property('foo.quux', str, lookup_env=True)
     given_first = config_property('foo.quuz', str, lookup_env=True)
@@ -396,8 +394,6 @@ def test_config_property_lookup_env():
     c = TestEnvAppConfig(foo={'quuz': 'gl'})
     assert c.env_lookup == 'hi', \
         'Get env var when given configuration is missing.'
-    assert c.env_with_name == 'gg', \
-        'Get env var which one has diffrent name.'
     assert c.given_first == 'gl', \
         'Get given configuration even if env var is exist.'
     # no look up env, no configration = Error

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -376,6 +376,8 @@ def parse_foo(d: typing.Mapping[str, str]):
 
 class TestEnvAppConfig(dict):
 
+    env_list = config_property('foo.list', list, lookup_env=True)
+    env_dict = config_property('foo.dict', dict, lookup_env=True)
     env_lookup = config_property('foo.bar', str, lookup_env=True)
     env_false = config_property('foo.qux', str, lookup_env=False)
     env_error = config_property('foo.quux', str, lookup_env=True)
@@ -391,17 +393,24 @@ class TestEnvAppConfig(dict):
     parse_object = config_object_property(
         'foo.parse',
         SampleInterface,
-        parse_env=parse_foo
+        parse_env=parse_foo,
+        lookup_env=True
     )
 
 
 def test_config_property_lookup_env():
+    os.environ['FOO__DICT__FOO'] = 'foo'
+    os.environ['FOO__DICT__BAR'] = 'bar'
+    os.environ['FOO__LIST__SETTEIENVLIST__0'] = 'foo'
+    os.environ['FOO__LIST__SETTEIENVLIST__1'] = 'bar'
     os.environ['FOO__BAR'] = 'hi'
     os.environ['LOREM_IPSUM'] = 'gg'
     os.environ['FOO__QUX'] = 'qux'
     os.environ['FOO__QUUZ'] = 'quuz'
     os.environ['FOO__EMPTY'] = ''
     c = TestEnvAppConfig(foo={'quuz': 'gl'})
+    assert c.env_list == ['foo', 'bar']
+    assert c.env_dict == {'foo': 'foo', 'bar': 'bar'}
     assert c.env_lookup == 'hi', \
         'Get env var when given configuration is missing.'
     assert c.given_first == 'gl', \

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,3 +1,4 @@
+import contextlib
 import enum
 import os
 import pathlib
@@ -10,6 +11,14 @@ from settei.base import (ConfigKeyError, ConfigTypeError,
                          Configuration, ConfigValueError, ConfigWarning,
                          config_object_property, config_property,
                          get_union_types)
+
+
+@contextlib.contextmanager
+def os_environ(d: typing.Mapping):
+    os.environ.update(d)
+    yield
+    for k in d:
+        del os.environ[k]
 
 
 class Enum1(enum.Enum):
@@ -372,7 +381,8 @@ class TestEnvAppConfig(dict):
     env_error = config_property('foo.quux', str, lookup_env=True)
     given_first = config_property('foo.quuz', str, lookup_env=True)
     parse = config_property('foo.parse', bool,
-                            lookup_env=True, parse_env=lambda x: x == 'True')
+                            lookup_env=True,
+                            parse_env=lambda x: x == 'True')
     empty_text = config_property('foo.empty', str, lookup_env=True)
     env_object = config_object_property('foo.obj', SampleInterface)
     recursiveobj = config_object_property('foo.recurse', SampleInterface,
@@ -381,7 +391,7 @@ class TestEnvAppConfig(dict):
     parse_object = config_object_property(
         'foo.parse',
         SampleInterface,
-        parse=parse_foo
+        parse_env=parse_foo
     )
 
 
@@ -407,54 +417,65 @@ def test_config_property_lookup_env():
 
 
 def test_config_property_convert_func():
-    os.environ['FOO__PARSE'] = 'True'
-    c = TestEnvAppConfig(foo={})
-    assert c.parse
-    os.environ['FOO__PARSE'] = 'False'
-    assert not c.parse
+    with os_environ({
+        'FOO__PARSE': 'True',
+    }):
+        c = TestEnvAppConfig(foo={})
+        assert c.parse
+    with os_environ({
+        'FOO__PARSE': 'False',
+    }):
+        c = TestEnvAppConfig(foo={})
+        assert not c.parse
 
 
 def test_config_object_property_env():
-    os.environ['FOO__OBJ__CLASS'] = __name__ + ':Impl'
-    os.environ['FOO__OBJ__FOO'] = 'foo'
-    os.environ['FOO__OBJ__BAR'] = 'bar'
-    c = TestEnvAppConfig(foo={})
-    assert c.env_object.kwargs == {
-        'foo': 'foo',
-        'bar': 'bar',
-    }
+    with os_environ({
+        'FOO__OBJ__CLASS': __name__ + ':Impl',
+        'FOO__OBJ__FOO': 'foo',
+        'FOO__OBJ__BAR': 'bar',
+    }):
+        c = TestEnvAppConfig(foo={})
+        assert c.env_object.kwargs == {
+            'foo': 'foo',
+            'bar': 'bar',
+        }
 
 
 def test_config_object_property_env_recurse():
-    os.environ['FOO__RECURSE__CLASS'] = __name__ + ':Impl'
-    os.environ['FOO__RECURSE__*__0'] = 'lorem'
-    os.environ['FOO__RECURSE__F__CLASS'] = __name__ + ':Impl'
-    os.environ['FOO__RECURSE__F__NESTED'] = 'true'
-    os.environ['FOO__RECURSE__F__RECURSIVE__CLASS'] = __name__ + ':Impl'
-    os.environ['FOO__RECURSE__F__RECURSIVE__NESTED'] = 'true'
-    os.environ['FOO__RECURSE__F__RECURSIVE__*__0'] = 'hi'
-    os.environ['FOO__RECURSE__F__RECURSIVE__*__1'] = 'mi'
-    os.environ['FOO__RECURSE__F__RECURSIVE__*__2'] = 'me'
-    c = TestEnvAppConfig(foo={})
-    v = c.recursiveobj
-    assert isinstance(v, Impl)
-    assert frozenset(v.kwargs) == frozenset({'f'})
-    assert v.args == ('lorem', )
-    f = v.kwargs['f']
-    assert isinstance(f, Impl)
-    assert f.args == ()
-    assert frozenset(f.kwargs) == frozenset({'nested', 'recursive'})
-    assert f.kwargs['nested'] == 'true'
-    r = f.kwargs['recursive']
-    assert isinstance(r, Impl)
-    assert r.args == ('hi', 'mi', 'me')
-    assert r.kwargs == {'nested': 'true'}
+    with os_environ({
+        'FOO__RECURSE__CLASS': __name__ + ':Impl',
+        'FOO__RECURSE__ASTERISK__0': 'lorem',
+        'FOO__RECURSE__F__CLASS': __name__ + ':Impl',
+        'FOO__RECURSE__F__NESTED': 'true',
+        'FOO__RECURSE__F__RECURSIVE__CLASS': __name__ + ':Impl',
+        'FOO__RECURSE__F__RECURSIVE__NESTED': 'true',
+        'FOO__RECURSE__F__RECURSIVE__ASTERISK__0': 'hi',
+        'FOO__RECURSE__F__RECURSIVE__ASTERISK__1': 'mi',
+        'FOO__RECURSE__F__RECURSIVE__ASTERISK__2': 'me',
+    }):
+        c = TestEnvAppConfig(foo={})
+        v = c.recursiveobj
+        assert isinstance(v, Impl)
+        assert frozenset(v.kwargs) == frozenset({'f'})
+        assert v.args == ('lorem', )
+        f = v.kwargs['f']
+        assert isinstance(f, Impl)
+        assert f.args == ()
+        assert frozenset(f.kwargs) == frozenset({'nested', 'recursive'})
+        assert f.kwargs['nested'] == 'true'
+        r = f.kwargs['recursive']
+        assert isinstance(r, Impl)
+        assert r.args == ('hi', 'mi', 'me')
+        assert r.kwargs == {'nested': 'true'}
 
 
 def test_config_object_property_env_parse():
-    os.environ['FOO__PARSE__CLASS'] = __name__ + ':Impl'
-    os.environ['FOO__PARSE__*__0'] = '1'
-    os.environ['FOO__PARSE__FOO'] = '3.14'
-    c = TestEnvAppConfig(foo={})
-    assert c.parse_object.args == (1, )
-    assert c.parse_object.kwargs == {'foo': 3.14}
+    with os_environ({
+        'FOO__PARSE__CLASS': __name__ + ':Impl',
+        'FOO__PARSE__ASTERISK__0': '1',
+        'FOO__PARSE__FOO': '3.14',
+    }):
+        c = TestEnvAppConfig(foo={})
+        assert c.parse_object.args == (1, )
+        assert c.parse_object.kwargs == {'foo': 3.14}


### PR DESCRIPTION
- Removed ``env_name`` paramter from
  `settei.base.config_object_property`.
- Changed asterisk charater into ``ASTERISK``. We couldn't use special
  charaters in OS environment variable name.
- Support list in environment variable.
- Allow configure value on both toml and environment variable at
  the same time.  Firstly settei get a configuration