### PR TITLE
Exclude tests folder from package

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ Version 0.7.2
 
 To be released.
 
+- Exclude `tests` module from package.
+
 Version 0.7.1
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     license='Apache 2.0',
     author='Spoqa Creators',
     author_email='dev' '@' 'spoqa.com',
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests', 'tests.*')),
     python_requires='>=3.4.0',
     install_requires=install_requires,
     extras_require=dict(


### PR DESCRIPTION
I think `tests` module should not be included in built package.

Before:

```
$ tar tzf dist/settei-0.7.2.tar.gz
settei-0.7.2/
settei-0.7.2/PKG-INFO
settei-0.7.2/README.rst
settei-0.7.2/settei/
settei-0.7.2/settei/__init__.py
settei-0.7.2/settei/base.py
settei-0.7.2/settei/parse_env.py
settei-0.7.2/settei/presets/
settei-0.7.2/settei/presets/__init__.py
settei-0.7.2/settei/presets/celery.py
settei-0.7.2/settei/presets/flask.py
settei-0.7.2/settei/presets/logging.py
settei-0.7.2/settei/utils.py
settei-0.7.2/settei/version.py
settei-0.7.2/settei.egg-info/
settei-0.7.2/settei.egg-info/PKG-INFO
settei-0.7.2/settei.egg-info/SOURCES.txt
settei-0.7.2/settei.egg-info/dependency_links.txt
settei-0.7.2/settei.egg-info/requires.txt
settei-0.7.2/settei.egg-info/top_level.txt
settei-0.7.2/setup.cfg
settei-0.7.2/setup.py
settei-0.7.2/tests/
settei-0.7.2/tests/__init__.py
settei-0.7.2/tests/base_test.py
settei-0.7.2/tests/parse_env_test.py
settei-0.7.2/tests/presets/
settei-0.7.2/tests/presets/__init__.py
settei-0.7.2/tests/presets/celery_test.py
settei-0.7.2/tests/presets/flask_test.py
settei-0.7.2/tests/presets/logging_test.py
```

After:

```
$ tar tzf dist/settei-0.7.2.tar.gz
settei-0.7.2/
settei-0.7.2/PKG-INFO
settei-0.7.2/README.rst
settei-0.7.2/settei/
settei-0.7.2/settei/__init__.py
settei-0.7.2/settei/base.py
settei-0.7.2/settei/parse_env.py
settei-0.7.2/settei/presets/
settei-0.7.2/settei/presets/__init__.py
settei-0.7.2/settei/presets/celery.py
settei-0.7.2/settei/presets/flask.py
settei-0.7.2/settei/presets/logging.py
settei-0.7.2/settei/utils.py
settei-0.7.2/settei/version.py
settei-0.7.2/settei.egg-info/
settei-0.7.2/settei.egg-info/PKG-INFO
settei-0.7.2/settei.egg-info/SOURCES.txt
settei-0.7.2/settei.egg-info/dependency_links.txt
settei-0.7.2/settei.egg-info/requires.txt
settei-0.7.2/settei.egg-info/top_level.txt
settei-0.7.2/setup.cfg
settei-0.7.2/setup.py
```